### PR TITLE
Abstract queue memory management

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -1,9 +1,26 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <pthread.h>
 
 #include "queue.h"
 
+
+queue_item_t *
+queue_item_create(void *data) {
+    queue_item_t *item;
+    if ((item = malloc(sizeof (queue_item_t))) == NULL) {
+        return NULL;
+    }
+
+    queue_item_init(item, data);
+    return item;
+}
+
+void
+queue_item_destroy(queue_item_t *item) {
+    free(item);
+}
 
 void
 queue_item_init(queue_item_t *item, void *data) {

--- a/queue.c
+++ b/queue.c
@@ -28,6 +28,26 @@ queue_item_init(queue_item_t *item, void *data) {
     item->data = data;
 }
 
+queue_t *
+queue_create(void) {
+    queue_t *queue;
+    if ((queue = malloc(sizeof (queue_t))) == NULL) {
+        return NULL;
+    }
+
+    queue_init(queue);
+    return queue;
+}
+
+void
+queue_destroy(queue_t *queue) {
+    while (!queue_empty(queue)) {
+        queue_item_destroy(queue_retrieve(queue));
+    }
+
+    free(queue);
+}
+
 void
 queue_init(queue_t *queue) {
     queue->head = NULL;

--- a/queue.h
+++ b/queue.h
@@ -30,6 +30,27 @@ typedef struct queue_t {
 } queue_t;
 
 /*
+ * Create a new queue_item_t object.
+ *
+ * This will create and initialize a new queue_item_t and return a handle to
+ * that object.
+ *
+ * This will return NULL if the queue_item_t could not be created.
+ */
+queue_item_t *
+queue_item_create(void *);
+
+/*
+ * Destroy a queue_item_t object.
+ *
+ * This will destroy a queue_item_t object, that is not needed anymore. This
+ * includes freeing up any memory associated with the queue_item_t object for
+ * example.
+ */
+void
+queue_item_destroy(queue_item_t *);
+
+/*
  * Initialize a new queue item.
  *
  * This must be called for any newly declared queue_item_t, before calling any

--- a/queue.h
+++ b/queue.h
@@ -60,6 +60,28 @@ void
 queue_item_init(queue_item_t *, void *);
 
 /*
+ * Create a new queue_t object.
+ *
+ * This will create and initialize a new queue_t and return a handle to that
+ * object.
+ *
+ * This will return NULL if the queue_t could not be created.
+ */
+queue_t *
+queue_create(void);
+
+/*
+ * Destroy a queue_t object.
+ *
+ * This will destroy a queue_t object, that is not needed anymore. This includes
+ * freeing up any memory associated with the queue_t object for example.
+ *
+ * No more left over items can be retrieved from the queue after destroying it.
+ */
+void
+queue_destroy(queue_t *);
+
+/*
  * Initialize a new queue.
  *
  * This must be called for any newly declared queue_t instance, before calling

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -10,13 +10,13 @@
 
 #define THREAD_POOL_SIZE 5
 
-queue_t queue;
+queue_t *queue;
 pthread_t thread_pool[THREAD_POOL_SIZE];
 
 void *
 thread_start_routine(void *arg) {
     while (true) {
-        queue_item_t *item = queue_retrieve(&queue);
+        queue_item_t *item = queue_retrieve(queue);
         task_execute((task_t *)item->data);
     }
 
@@ -39,11 +39,18 @@ thread_pool_join(void) {
 
 int
 main(void) {
-    queue_init(&queue);
+    if ((queue = queue_create()) == NULL) {
+        fprintf("Task queue could not be created.");
+        return EXIT_FAILURE;
+    }
+
     thread_pool_init();
 
     // TODO(Jim Gerth): Add tasks to queue.
 
     thread_pool_join();
+
+    queue_destroy(queue);
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Instead of the user having to store `queue_t`s and `queue_item_t`s, rather make the user store only a reference to the internally managed objects.

For this supply the user with `*_create()` and `*_destroy()` functions for the `queue_t` and the `queue_item_t`. that they can use to obtain a reference.

This fixes #13.