### PR TITLE
Remove stale queue handles

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -18,8 +18,9 @@ queue_item_create(void *data) {
 }
 
 void
-queue_item_destroy(queue_item_t *item) {
-    free(item);
+queue_item_destroy(queue_item_t **item) {
+    free(*item);
+    *item = NULL;
 }
 
 void

--- a/queue.c
+++ b/queue.c
@@ -55,7 +55,8 @@ queue_destroy(queue_t **queue) {
     }
 
     while (!queue_empty(*queue)) {
-        queue_item_destroy(queue_retrieve(*queue));
+        queue_item_t *item = queue_retrieve(*queue);
+        queue_item_destroy(&item);
     }
 
     free(*queue);

--- a/queue.c
+++ b/queue.c
@@ -40,12 +40,13 @@ queue_create(void) {
 }
 
 void
-queue_destroy(queue_t *queue) {
-    while (!queue_empty(queue)) {
-        queue_item_destroy(queue_retrieve(queue));
+queue_destroy(queue_t **queue) {
+    while (!queue_empty(*queue)) {
+        queue_item_destroy(queue_retrieve(*queue));
     }
 
-    free(queue);
+    free(*queue);
+    *queue = NULL;
 }
 
 void

--- a/queue.c
+++ b/queue.c
@@ -42,6 +42,10 @@ queue_create(void) {
 
 void
 queue_destroy(queue_t **queue) {
+    if (queue == NULL) {
+        return;
+    }
+
     while (!queue_empty(*queue)) {
         queue_item_destroy(queue_retrieve(*queue));
     }
@@ -52,6 +56,10 @@ queue_destroy(queue_t **queue) {
 
 void
 queue_init(queue_t *queue) {
+    if (queue == NULL) {
+        return;
+    }
+
     queue->head = NULL;
     queue->tail = NULL;
     pthread_mutex_init(&queue->mutex, NULL);
@@ -60,11 +68,19 @@ queue_init(queue_t *queue) {
 
 bool
 queue_empty(queue_t *queue) {
+    if (queue == NULL) {
+        return true;
+    }
+
     return queue->head == NULL;
 }
 
 void
 queue_submit(queue_t *queue, queue_item_t *item) {
+    if (queue == NULL) {
+        return;
+    }
+
     pthread_mutex_lock(&queue->mutex);
 
     if (queue_empty(queue)) {
@@ -82,6 +98,10 @@ queue_submit(queue_t *queue, queue_item_t *item) {
 
 queue_item_t *
 queue_retrieve(queue_t *queue) {
+    if (queue == NULL) {
+        return NULL;
+    }
+
     pthread_mutex_lock(&queue->mutex);
 
     while (queue_empty(queue)) {

--- a/queue.c
+++ b/queue.c
@@ -19,12 +19,20 @@ queue_item_create(void *data) {
 
 void
 queue_item_destroy(queue_item_t **item) {
+    if (item == NULL) {
+        return;
+    }
+
     free(*item);
     *item = NULL;
 }
 
 void
 queue_item_init(queue_item_t *item, void *data) {
+    if (item == NULL) {
+        return;
+    }
+
     item->next = NULL;
     item->data = data;
 }

--- a/queue.h
+++ b/queue.h
@@ -48,7 +48,7 @@ queue_item_create(void *);
  * example.
  */
 void
-queue_item_destroy(queue_item_t *);
+queue_item_destroy(queue_item_t **);
 
 /*
  * Initialize a new queue item.

--- a/queue.h
+++ b/queue.h
@@ -79,7 +79,7 @@ queue_create(void);
  * No more left over items can be retrieved from the queue after destroying it.
  */
 void
-queue_destroy(queue_t *);
+queue_destroy(queue_t **);
 
 /*
  * Initialize a new queue.

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -50,7 +50,7 @@ main(void) {
 
     thread_pool_join();
 
-    queue_destroy(queue);
+    queue_destroy(&queue);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Previously users of the queue module would keep a stale handle to a `queue_t` or `queue_item_t` even after calling the respective `*_destroy()` function, possibly leading to illegal memory accesses.
This is further described in the linked issue.

This fixes #12.