### PR TITLE
Fix call to fprintf

### DIFF
--- a/thread_pool.c
+++ b/thread_pool.c
@@ -40,7 +40,7 @@ thread_pool_join(void) {
 int
 main(void) {
     if ((queue = queue_create()) == NULL) {
-        fprintf("Task queue could not be created.");
+        fprintf(stderr, "Task queue could not be created.");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
Add missing file descriptor argument to `fprintf()` call in `thread_pool.c`.

This fixes #17.