### PR TITLE
Internalize queue functions

### DIFF
--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -48,15 +48,6 @@ void
 queue_destroy(queue_t **);
 
 /*
- * Initialize a new queue.
- *
- * This must be called for any newly declared queue_t instance, before calling
- * any other queue_* function with it.
- */
-void
-queue_init(queue_t *);
-
-/*
  * Return whether the given queue is empty.
  */
 bool

--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -5,10 +5,11 @@
 /*
  * Create a new queue_t object.
  *
- * This will create and initialize a new queue_t and return a handle to that
- * object.
+ * This will create and initialize a new queue and return a handle to it. That
+ * handle can be used with the various queue_*() functions to manipulate the
+ * queue, by passing it in as the first argument.
  *
- * This will return NULL if the queue_t could not be created.
+ * This will return NULL if the queue could not be created.
  */
 queue_t *
 queue_create(void);
@@ -19,7 +20,7 @@ queue_create(void);
  * This will destroy a queue_t object, that is not needed anymore. This includes
  * freeing up any memory associated with the queue_t object for example.
  *
- * No more left over items can be retrieved from the queue after destroying it.
+ * No more left over data can be retrieved from the queue after destroying it.
  */
 void
 queue_destroy(queue_t **);

--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -1,8 +1,6 @@
 #ifndef __QUEUE_EXTERNAL_FUNCTIONS_H__
 #define __QUEUE_EXTERNAL_FUNCTIONS_H__
 
-#include <stdbool.h>
-
 
 /*
  * Create a new queue_item_t object.
@@ -46,12 +44,6 @@ queue_create(void);
  */
 void
 queue_destroy(queue_t **);
-
-/*
- * Return whether the given queue is empty.
- */
-bool
-queue_empty(queue_t *);
 
 /*
  * Add the given data to the given queue.

--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -26,15 +26,6 @@ void
 queue_item_destroy(queue_item_t **);
 
 /*
- * Initialize a new queue item.
- *
- * This must be called for any newly declared queue_item_t, before calling any
- * other queue_* function with it.
- */
-void
-queue_item_init(queue_item_t *, void *);
-
-/*
  * Create a new queue_t object.
  *
  * This will create and initialize a new queue_t and return a handle to that

--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -3,17 +3,6 @@
 
 
 /*
- * Create a new queue_item_t object.
- *
- * This will create and initialize a new queue_item_t and return a handle to
- * that object.
- *
- * This will return NULL if the queue_item_t could not be created.
- */
-queue_item_t *
-queue_item_create(void *);
-
-/*
  * Destroy a queue_item_t object.
  *
  * This will destroy a queue_item_t object, that is not needed anymore. This

--- a/queue/external_functions.h
+++ b/queue/external_functions.h
@@ -3,16 +3,6 @@
 
 
 /*
- * Destroy a queue_item_t object.
- *
- * This will destroy a queue_item_t object, that is not needed anymore. This
- * includes freeing up any memory associated with the queue_item_t object for
- * example.
- */
-void
-queue_item_destroy(queue_item_t **);
-
-/*
  * Create a new queue_t object.
  *
  * This will create and initialize a new queue_t and return a handle to that

--- a/queue/external_typedefs.h
+++ b/queue/external_typedefs.h
@@ -3,11 +3,6 @@
 
 
 /*
- * An enqueueable item with a generic data payload.
- */
-typedef void queue_item_t;
-
-/*
  * A queue of items with a generic data payload.
  *
  * This queue serves as a "first in, first out" buffer, keeping track of

--- a/queue/external_typedefs.h
+++ b/queue/external_typedefs.h
@@ -3,13 +3,12 @@
 
 
 /*
- * A queue of items with a generic data payload.
+ * A queue of generic data.
  *
- * This queue serves as a "first in, first out" buffer, keeping track of
- * references to queue items, which in turn keep track of arbitrary data. New
- * items can be inserted into the queue (submitted), while items already in the
- * queue can be removed again (retrieved). Items will be retrieved in the same
- * order they were previously submitted.
+ * This queue serves as a "first in, first out" buffer, keeping track of generic
+ * data. New data can be inserted into the queue (submitted), while data already
+ * in the queue can be removed again (retrieved). Data will be retrieved in the
+ * same order it was previously submitted.
  */
 typedef void queue_t;
 

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -26,6 +26,6 @@ queue_init(queue_t *);
  * Return whether the given queue is empty.
  */
 bool
-queue_empty(queue_t *);
+queue_is_empty(queue_t *);
 
 #endif

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -7,8 +7,9 @@
 /*
  * Create a new queue_item_t object.
  *
- * This will create and initialize a new queue_item_t and return a handle to
- * that object.
+ * This will create and initialize a new queue item and return a handle to it.
+ * That handle can be used with the various queue_item_*() functions to
+ * manipulate the queue item, by passing it in as the first argument.
  *
  * This will return NULL if the queue_item_t could not be created.
  */

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -25,6 +25,16 @@ void
 queue_item_init(queue_item_t *, void *);
 
 /*
+ * Destroy a queue_item_t object.
+ *
+ * This will destroy a queue_item_t object, that is not needed anymore. This
+ * includes freeing up any memory associated with the queue_item_t object for
+ * example.
+ */
+void
+queue_item_destroy(queue_item_t **);
+
+/*
  * Initialize a new queue.
  *
  * This must be called for any newly declared queue_t instance, before calling

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -11,4 +11,13 @@
 void
 queue_item_init(queue_item_t *, void *);
 
+/*
+ * Initialize a new queue.
+ *
+ * This must be called for any newly declared queue_t instance, before calling
+ * any other queue_* function with it.
+ */
+void
+queue_init(queue_t *);
+
 #endif

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -1,6 +1,8 @@
 #ifndef __QUEUE_INTERNAL_FUNCTIONS_H__
 #define __QUEUE_INTERNAL_FUNCTIONS_H__
 
+#include <stdbool.h>
+
 
 /*
  * Initialize a new queue item.
@@ -19,5 +21,11 @@ queue_item_init(queue_item_t *, void *);
  */
 void
 queue_init(queue_t *);
+
+/*
+ * Return whether the given queue is empty.
+ */
+bool
+queue_empty(queue_t *);
 
 #endif

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -5,6 +5,17 @@
 
 
 /*
+ * Create a new queue_item_t object.
+ *
+ * This will create and initialize a new queue_item_t and return a handle to
+ * that object.
+ *
+ * This will return NULL if the queue_item_t could not be created.
+ */
+queue_item_t *
+queue_item_create(void *);
+
+/*
  * Initialize a new queue item.
  *
  * This must be called for any newly declared queue_item_t, before calling any

--- a/queue/internal_functions.h
+++ b/queue/internal_functions.h
@@ -2,4 +2,13 @@
 #define __QUEUE_INTERNAL_FUNCTIONS_H__
 
 
+/*
+ * Initialize a new queue item.
+ *
+ * This must be called for any newly declared queue_item_t, before calling any
+ * other queue_* function with it.
+ */
+void
+queue_item_init(queue_item_t *, void *);
+
 #endif

--- a/queue/queue.c
+++ b/queue/queue.c
@@ -54,7 +54,7 @@ queue_destroy(queue_t **queue) {
         return;
     }
 
-    while (!queue_empty(*queue)) {
+    while (!queue_is_empty(*queue)) {
         queue_item_t *item = queue_retrieve(*queue);
         queue_item_destroy(&item);
     }
@@ -76,7 +76,7 @@ queue_init(queue_t *queue) {
 }
 
 bool
-queue_empty(queue_t *queue) {
+queue_is_empty(queue_t *queue) {
     if (queue == NULL) {
         return true;
     }
@@ -95,7 +95,7 @@ queue_submit(queue_t *queue, void *data) {
 
     pthread_mutex_lock(&queue->mutex);
 
-    if (queue_empty(queue)) {
+    if (queue_is_empty(queue)) {
         queue->head = item;
     } else {
         queue->tail->next = item;
@@ -116,7 +116,7 @@ queue_retrieve(queue_t *queue) {
 
     pthread_mutex_lock(&queue->mutex);
 
-    while (queue_empty(queue)) {
+    while (queue_is_empty(queue)) {
         pthread_cond_wait(&queue->not_empty, &queue->mutex);
     }
 


### PR DESCRIPTION
Based on the merged #19, now there is proper control over what parts of the queue code are exposed and what parts are hidden to the user.
This use that opportunity to properly internalize some functions, that should only be internal to the queue module and not be callable from the outside, namely:

- [x] `queue_item_init()`
- [x] `queue_init()`
- [x] `queue_empty()` (`-> queue_is_empty()`)